### PR TITLE
Lowered logging level when buffer isn't full to reduce excessive logging

### DIFF
--- a/http.axi
+++ b/http.axi
@@ -548,7 +548,7 @@ define_function integer httpParseResponse(HttpResponse response, char buffer[]) 
 		contentLength = atoi(values[1]);
 		
 		if(length_array(workingBuffer)<contentLength) {
-			AMX_LOG(AMX_ERROR,"'http-alt::httpParseResponse...returning(false) - buffer does not contain enough data'");
+			AMX_LOG(AMX_DEBUG,"'http-alt::httpParseResponse...returning(false) - buffer does not contain enough data'");
 			return false;
 		}
 		


### PR DESCRIPTION
Hi Dave,

Just another pull request here. Currently the HTTP module logs an incomplete request as an AMX_ERROR, I think it would be more appropriate as an AMX_DEBUG.

Thanks,
Jim M